### PR TITLE
Removal of --api-servers

### DIFF
--- a/files/kubeconfig.yaml
+++ b/files/kubeconfig.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: http://localhost:8080
+contexts:
+- context:
+    cluster: local
+  name: kubelet-context
+current-context: kubelet-context

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,12 @@
   with_items: [ "kube-apiserver", "kube-controller-manager", "kube-scheduler" ]
   tags: kubernetes-manifest
 
+- name: write kubelet kubeconfig
+  copy:
+    src: kubeconfig.yaml
+    dest: /etc/kubernetes/kubeconfig.yaml
+  mode: 0644
+
 - name: Kubelet systemd service
   template:
     src: kubelet.service.j2

--- a/templates/kubelet.service.j2
+++ b/templates/kubelet.service.j2
@@ -9,7 +9,7 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=http://127.0.0.1:8080 \
+  --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
   --register-schedulable=false \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin={{ vars.kubernetes.network_plugin }} \


### PR DESCRIPTION
With k8s 1.8 and above --api-servers has been deprecated/removed in favor of kubeconfig. 